### PR TITLE
Start rendering from first frame specified

### DIFF
--- a/livre/Eq/Client.cpp
+++ b/livre/Eq/Client.cpp
@@ -185,13 +185,15 @@ int Client::run()
     uint32_t frames = _applicationParameters.frames.y() -_applicationParameters.frames.x() + 1;
 
     clock.reset();
-    frameData.getCameraSettings()->setCameraPosition(
-                _applicationParameters.cameraPosition );
+    frameData.getCameraSettings()->setCameraPosition( _applicationParameters.cameraPosition );
 
-    while( config->isRunning() && frames-- )
+    while( config->isRunning() && frames )
     {
         config->startFrame();
         config->finishFrame();
+
+        if( _applicationParameters.animationEnabled )
+            frames--;
     }
 
     const uint32_t frame = config->finishAllFrames();

--- a/livre/Eq/Window.cpp
+++ b/livre/Eq/Window.cpp
@@ -91,13 +91,10 @@ public:
         node->getDashTree()->getRenderStatus().setThreadOp( TO_EXIT );
     }
 
-    void frameStart()
+    void frameStart( const uint32_t frameNumber )
     {
         _dashProcessorPtr->getDashContext()->setCurrent();
-    }
 
-    void frameFinish( const uint32_t frameNumber )
-    {
         livre::Node* node = static_cast< livre::Node* >( _window->getNode( ));
         DashRenderStatus& renderStatus = node->getDashTree()->getRenderStatus();
 
@@ -105,7 +102,11 @@ public:
         const uint32_t startFrame = pipe->getFrameData()->getAppParameters()->frames.x();
 
         if( pipe->getFrameData()->getAppParameters()->animationEnabled )
-            renderStatus.setFrameID( frameNumber + startFrame );
+            renderStatus.setFrameID( startFrame + frameNumber - 1 );
+        else
+            renderStatus.setFrameID( startFrame );
+
+        commit();
     }
 
     void startUploadProcessors()
@@ -268,14 +269,13 @@ bool Window::configExitGL()
 void Window::frameStart( const eq::uint128_t& frameID,
                          const uint32_t frameNumber )
 {
-    _impl->frameStart();
+    _impl->frameStart( frameNumber );
     eq::Window::frameStart( frameID, frameNumber );
 }
 
 void Window::frameFinish( const eq::uint128_t& frameID,
                           const uint32_t frameNumber )
 {
-    _impl->frameFinish( frameNumber );
     eq::Window::frameFinish( frameID, frameNumber );
 }
 


### PR DESCRIPTION
Fix a bug that always rendered frame 0 at the beginning.
Finish the execution only when animation mode is enabled.