### PR TITLE
Fix regression issue that skipped every other frame

### DIFF
--- a/livre/Eq/Client.cpp
+++ b/livre/Eq/Client.cpp
@@ -182,18 +182,15 @@ int Client::run()
                        << std::endl;
 
     // 4. run main loop
-    uint32_t frames = _applicationParameters.frames.y() -_applicationParameters.frames.x() + 1;
+    uint32_t maxFrames = _applicationParameters.maxFrames;
 
     clock.reset();
     frameData.getCameraSettings()->setCameraPosition( _applicationParameters.cameraPosition );
 
-    while( config->isRunning() && frames )
+    while( config->isRunning() && maxFrames-- )
     {
         config->startFrame();
         config->finishFrame();
-
-        if( _applicationParameters.animationEnabled )
-            frames--;
     }
 
     const uint32_t frame = config->finishAllFrames();

--- a/livre/Lib/Configuration/ApplicationParameters.cpp
+++ b/livre/Lib/Configuration/ApplicationParameters.cpp
@@ -18,16 +18,17 @@
  */
 
 #include <livre/Lib/Configuration/ApplicationParameters.h>
+#include <livre/core/mathTypes.h>
 
 namespace vmml
 {
 
-std::istream& operator>>( std::istream& is, vmml::vector<3ul, float>& vec )
+std::istream& operator>>( std::istream& is, Vector3f& vec )
 {
     return is >> std::skipws >> vec.x() >> vec.y() >> vec.z();
 }
 
-std::istream& operator>>( std::istream& is, vmml::vector<2ul, int>& vec )
+std::istream& operator>>( std::istream& is, Vector2ui& vec )
 {
     return is >> std::skipws >> vec.x() >> vec.y();
 }
@@ -47,7 +48,8 @@ const std::string SYNC_CAMERA_PARAM = "sync-camera";
 ApplicationParameters::ApplicationParameters()
     : Parameters( "Application Parameters" )
     , animationEnabled( false )
-    , frames( Vector2i( 0, std::numeric_limits<int>::max( )))
+    , frames( Vector2ui( 0, std::numeric_limits< Vector2ui::value_type >::max( )))
+    , maxFrames(-1u )
     , isResident( false )
     , cameraPosition( Vector3f( 0, 0, -2.0 ))
     , syncCamera( false )
@@ -58,6 +60,8 @@ ApplicationParameters::ApplicationParameters()
                                    "Enable animation mode", animationEnabled );
     configuration_.addDescription( configGroupName_, FRAMES_PARAM,
                                    "Frames to render 'start end'", frames );
+    configuration_.addDescription( configGroupName_, NUMFRAMES_PARAM,
+                                   "Maximum nuber of frames to render", maxFrames );
     configuration_.addDescription( configGroupName_, CAMERAPOS_PARAM,
                                    "Camera position", cameraPosition );
 #ifdef LIVRE_USE_ZEQ
@@ -75,6 +79,7 @@ void ApplicationParameters::serialize( co::DataOStream &os,
     os << dataFileName
        << animationEnabled
        << frames
+       << maxFrames
        << isResident
        << cameraPosition
        << syncCamera;
@@ -89,6 +94,7 @@ ApplicationParameters& ApplicationParameters::operator=(
     dataFileName = parameters.dataFileName;
     animationEnabled = parameters.animationEnabled;
     frames = parameters.frames;
+    maxFrames = parameters.maxFrames;
     isResident = parameters.isResident;
     cameraPosition = parameters.cameraPosition;
     syncCamera = parameters.syncCamera;
@@ -104,6 +110,7 @@ void ApplicationParameters::deserialize( co::DataIStream &is,
     is >> dataFileName
        >> animationEnabled
        >> frames
+       >> maxFrames
        >> isResident
        >> cameraPosition
        >> syncCamera;
@@ -114,6 +121,7 @@ void ApplicationParameters::initialize_()
     configuration_.getValue( DATAFILE_PARAM, dataFileName );
     configuration_.getValue( ANIMATIONENABLED_PARAM, animationEnabled );
     configuration_.getValue( FRAMES_PARAM, frames );
+    configuration_.getValue( NUMFRAMES_PARAM, maxFrames );
     configuration_.getValue( CAMERAPOS_PARAM, cameraPosition );
     configuration_.getValue( SYNC_CAMERA_PARAM, syncCamera );
 }

--- a/livre/Lib/Configuration/ApplicationParameters.h
+++ b/livre/Lib/Configuration/ApplicationParameters.h
@@ -35,7 +35,8 @@ struct ApplicationParameters : public Parameters
 
     std::string dataFileName; //!< Data file name.
     bool animationEnabled; //!< Enable the animation mode.
-    Vector2i frames; //!< Range of frames to render: 'start end'.
+    Vector2ui frames; //!< Range of frames to render: 'start end'.
+    uint32_t maxFrames; //!< Max number of frames to render.
     bool isResident; //!< Is the main app resident.
     Vector3f cameraPosition; //!< Camera position in world space.
     bool syncCamera; //!< Synchronize camera with other applications using ZEQ.


### PR DESCRIPTION
Recovered the --maxFrames option, which can be used together with
--frames to have animation loops