### PR TITLE
The texture objects are referenced directly from cache

### DIFF
--- a/livre/core/cache/Cache.cpp
+++ b/livre/core/cache/Cache.cpp
@@ -33,6 +33,11 @@ CacheObjectPtr Cache::getObjectFromCache( const CacheId cacheObjectID )
     return getObjectFromCache_( cacheObjectID );
 }
 
+CacheObjectPtr Cache::getObjectFromCache( const CacheId cacheObjectID ) const
+{
+    return getObjectFromCache_( cacheObjectID );
+}
+
 Cache::ApplyResult Cache::applyPolicy( CachePolicy& cachePolicy ) const
 {
     ReadLock readLock( mutex_, boost::try_to_lock );

--- a/livre/core/cache/Cache.h
+++ b/livre/core/cache/Cache.h
@@ -54,6 +54,13 @@ public:
     LIVRECORE_API CacheObjectPtr getObjectFromCache( const CacheId cacheObjectID );
 
     /**
+     * @param cacheObjectID The object cache id to be queried.
+     * @return The cache object from cache, if object is not in the list an empty cache
+     * object is returned.
+     */
+    LIVRECORE_API CacheObjectPtr getObjectFromCache( const CacheId cacheObjectID ) const;
+
+    /**
      * Applies a policy to the cache.
      * @param cachePolicy The policy to be applied to cache.
      * @return The state for the cache policy application.

--- a/livre/core/dash/DashRenderNode.cpp
+++ b/livre/core/dash/DashRenderNode.cpp
@@ -27,7 +27,7 @@ enum DashAttributeType
     DNT_NODE              ,
     DNT_TEXTUREDATA       ,
     DNT_TEXTURE           ,
-    DNT_VISIBLE           ,
+    DNT_LODVISIBLE           ,
     DNT_INFRUSTUM         ,
     DNT_CACHE_MODIFIED
 };
@@ -56,9 +56,9 @@ bool DashRenderNode::isInFrustum( ) const
     return getAttribute_< bool >( DNT_INFRUSTUM );
 }
 
-bool DashRenderNode::isVisible( ) const
+bool DashRenderNode::isLODVisible( ) const
 {
-    return getAttribute_< bool >( DNT_VISIBLE );
+    return getAttribute_< bool >( DNT_LODVISIBLE );
 }
 
 void DashRenderNode::setLODNode( const LODNode& node )
@@ -83,7 +83,7 @@ void DashRenderNode::setInFrustum( bool visibility )
 
 void DashRenderNode::setVisible( bool visibility )
 {
-    *(_dashNode->getAttribute( DNT_VISIBLE )) = visibility;
+    *(_dashNode->getAttribute( DNT_LODVISIBLE )) = visibility;
 }
 
 void DashRenderNode::initializeDashNode( dash::NodePtr dashNode )
@@ -103,9 +103,9 @@ void DashRenderNode::initializeDashNode( dash::NodePtr dashNode )
     *texture = lodTexture;
     dashNode->insert( texture );
 
-    dash::AttributePtr isVisible = new dash::Attribute();
-    *isVisible = false;
-    dashNode->insert( isVisible );
+    dash::AttributePtr isLODVisible = new dash::Attribute();
+    *isLODVisible = false;
+    dashNode->insert( isLODVisible );
 
     dash::AttributePtr isInFrustum = new dash::Attribute();
     *isInFrustum = true;

--- a/livre/core/dash/DashRenderNode.h
+++ b/livre/core/dash/DashRenderNode.h
@@ -70,7 +70,7 @@ public:
      * @return True, if object is visible.
      * @warning This condition is set from outside of the object.
      */
-    LIVRECORE_API bool isVisible() const;
+    LIVRECORE_API bool isLODVisible() const;
 
     /**
      * @return True, if object is in frustum.

--- a/livre/core/dash/DashTree.cpp
+++ b/livre/core/dash/DashTree.cpp
@@ -76,20 +76,27 @@ public:
         return getDashNode( parentNodeId ) ;
     }
 
+    dash::NodePtr getDashNode( const NodeId& nodeId) const
+    {
+        ReadLock readLock( _mutex );
+        NodeIDDashNodePtrMap::const_iterator it = _dashNodeMap.find( nodeId );
+        return it == _dashNodeMap.end() ? dash::NodePtr() : it->second;
+    }
+
     dash::NodePtr getDashNode( const NodeId& nodeId )
     {
         // "Double-Checked Locking" idiom is used below.
         LBASSERT( &_localContext != &dash::Context::getCurrent() );
         ReadLock readLock( _mutex );
         NodeIDDashNodePtrMap::const_iterator it = _dashNodeMap.find( nodeId );
-        if( it != _dashNodeMap.end() )
+        if( it != _dashNodeMap.end( ))
             return it->second;
 
         readLock.unlock();
 
         WriteLock writeLock( _mutex );
         it = _dashNodeMap.find( nodeId );
-        if( it != _dashNodeMap.end() )
+        if( it != _dashNodeMap.end( ))
             return it->second;
 
         dash::Context& prevCtx = dash::Context::getCurrent();
@@ -158,6 +165,11 @@ const dash::NodePtr DashTree::getParentNode( const NodeId& nodeId )
 dash::NodePtr DashTree::getDashNode( const NodeId& nodeId )
 {
     return _impl->getDashNode( nodeId ) ;
+}
+
+dash::NodePtr DashTree::getDashNode( const NodeId& nodeId) const
+{
+     return _impl->getDashNode( nodeId ) ;
 }
 
 }

--- a/livre/core/dash/DashTree.h
+++ b/livre/core/dash/DashTree.h
@@ -73,6 +73,11 @@ public:
      */
     LIVRECORE_API dash::NodePtr getDashNode( const NodeId& nodeId );
 
+    /**
+     * @return a node by its nodeId, returns an empty node if there is no nodeId.
+     */
+    LIVRECORE_API dash::NodePtr getDashNode( const NodeId& nodeId ) const;
+
 private:
     detail::DashTree* _impl;
 };

--- a/livre/core/data/NodeId.h
+++ b/livre/core/data/NodeId.h
@@ -112,6 +112,20 @@ public:
      */
     LIVRECORE_API bool operator!=( const Identifier id ) const
         { return _id != id; } //<! Checks equality of the node
+
+    /**
+     * @param id The identifier which is compared against
+     * @return true if id is smaller
+     */
+    LIVRECORE_API bool operator<( const NodeId& node ) const
+        { return _id < node._id; } //<! Checks equality of the node
+
+    /**
+     * @param id The identifier which is compared against
+     * @return true if id is smaller
+     */
+    LIVRECORE_API bool operator<( const Identifier id ) const
+        { return _id < id; } //<! Checks equality of the node
 };
 
 /**

--- a/livre/core/render/TexturePoolFactory.cpp
+++ b/livre/core/render/TexturePoolFactory.cpp
@@ -34,10 +34,8 @@ TexturePoolPtr TexturePoolFactory::findTexturePool( const Vector3i& maxBlockSize
                                                     const GLenum format,
                                                     const GLenum gpuDataType )
 {
-    for( TexturePoolPtrVector::iterator it = texturePoolList_.begin();
-         it != texturePoolList_.end(); ++it )
+    BOOST_FOREACH( TexturePoolPtr& pool, texturePools_  )
     {
-        TexturePoolPtr pool = *it;
         if( maxBlockSize == pool->getMaxBlockSize() &&
            format == pool->getFormat() &&
             gpuDataType == pool->getGPUDataType() )
@@ -50,7 +48,7 @@ TexturePoolPtr TexturePoolFactory::findTexturePool( const Vector3i& maxBlockSize
                                            internalFormat_,
                                            format,
                                            gpuDataType ) );
-    texturePoolList_.push_back( pool );
+    texturePools_.push_back( pool );
     return pool;
 }
 

--- a/livre/core/render/TexturePoolFactory.h
+++ b/livre/core/render/TexturePoolFactory.h
@@ -51,7 +51,7 @@ public:
 private:
 
     const int32_t internalFormat_;
-    std::vector< TexturePoolPtr > texturePoolList_;
+    TexturePools texturePools_;
 };
 
 

--- a/livre/core/render/View.cpp
+++ b/livre/core/render/View.cpp
@@ -62,9 +62,9 @@ void View::render( const FrameInfo& frameInfo,
         return ;
 
 #ifndef LIVRE_DEBUG_RENDERING
-    const unsigned long all = static_cast< unsigned long >( frameInfo.allNodesList.size( ));
+    const unsigned long all = static_cast< unsigned long >( frameInfo.allNodes.size( ));
     const unsigned long haveNot =
-        static_cast< unsigned long >( frameInfo.notAvailableRenderNodeList.size( ));
+        static_cast< unsigned long >( frameInfo.notAvailableRenderNodes.size( ));
     const unsigned long have = all - haveNot;
 
     if( progress_.expected_count() != all )

--- a/livre/core/render/View.h
+++ b/livre/core/render/View.h
@@ -21,6 +21,7 @@
 #define _View_h_
 
 #include <livre/core/api.h>
+#include <livre/core/cache/CacheObject.h>
 #include <livre/core/dashTypes.h>
 #include <livre/core/mathTypes.h>
 #include <livre/core/lunchboxTypes.h>
@@ -36,9 +37,9 @@ namespace livre
 struct FrameInfo
 {
     LIVRECORE_API FrameInfo( const Frustum& cFrustum );
-    DashNodeVector allNodesList; //!< The list of nodes to be rendered.
-    DashNodeVector renderNodeList; //!< The list of nodes to be rendered.
-    DashNodeVector notAvailableRenderNodeList; //!< The unavailable nodes for rendering.
+    NodeIds allNodes; //!< The list of nodes to be rendered.
+    NodeIds notAvailableRenderNodes; //!< The unavailable nodes for rendering.
+    ConstCacheObjects renderNodes; //!< The list of nodes to be rendered.
     const Frustum& currentFrustum; //!< The current frustum.
 };
 

--- a/livre/core/types.h
+++ b/livre/core/types.h
@@ -185,11 +185,10 @@ typedef std::vector< NodeId > NodeIds;
 /**
  * Vector definitions for complex types
  */
-typedef std::vector< ConstCacheObjectPtr > ConstCacheObjectPtrVector;
+typedef std::vector< CacheObjectPtr > CacheObjects;
+typedef std::vector< ConstCacheObjectPtr > ConstCacheObjects;
 typedef std::vector< RenderBrickPtr > RenderBricks;
-typedef std::vector< VolumeDataSourcePtr > VolumeDataSourcePtrVector;
-typedef std::vector< TexturePoolPtr > TexturePoolPtrVector;
-typedef std::vector< DashTreePtr > DashTreePtrVector;
+typedef std::vector< TexturePoolPtr > TexturePools;
 
 /**
  * Map definitions
@@ -197,6 +196,7 @@ typedef std::vector< DashTreePtr > DashTreePtrVector;
 typedef boost::unordered_map< NodeId, LODNodePtr > NodeIDLODNodePtrMap;
 typedef boost::unordered_map< NodeId, dash::NodePtr > NodeIDDashNodePtrMap;
 typedef boost::unordered_map< CacheId, CacheObjectPtr > CacheMap;
+typedef boost::unordered_map< CacheId, ConstCacheObjectPtr > ConstCacheMap;
 typedef boost::unordered_map< uint32_t, bool > BoolMap;
 typedef boost::unordered_map< uint32_t, EventHandlerPtr > EventHandlerPtrMap;
 typedef boost::unordered_map< uint32_t, DashConnectionPtr > DashConnectionPtrMap;

--- a/livre/lib/render/AvailableSetGenerator.h
+++ b/livre/lib/render/AvailableSetGenerator.h
@@ -22,6 +22,7 @@
 
 #include <livre/core/render/RenderingSetGenerator.h>
 #include <livre/lib/api.h>
+#include <livre/lib/types.h>
 
 namespace livre
 {
@@ -35,10 +36,12 @@ class AvailableSetGenerator : public RenderingSetGenerator
 public:
     /**
      * @param tree The initialized dash tree with the volume.
-     * @param windowHeight View height in pixels.
-     * @param screenSpaceError Screen space error in pixels.
+     * @param texture cache
      */
-    LIVRE_API AvailableSetGenerator( DashTreePtr tree);
+    LIVRE_API AvailableSetGenerator( DashTreePtr tree,
+                                     const TextureCache& textureCache );
+
+    ~ AvailableSetGenerator();
 
     /**
      * Generates the rendering set according to the given frustum.
@@ -47,6 +50,11 @@ public:
      */
     LIVRE_API void generateRenderingSet( const Frustum& viewFrustum,
                                          FrameInfo& frameInfo );
+
+private:
+
+    struct Impl;
+    Impl* _impl;
 };
 
 

--- a/livre/lib/render/RenderView.h
+++ b/livre/lib/render/RenderView.h
@@ -25,7 +25,6 @@
 #include <livre/core/render/View.h>
 #include <livre/core/render/Frustum.h>
 #include <livre/core/dash/DashRenderNode.h>
-#include <livre/lib/visitor/DFSTraversal.h>
 #include <livre/lib/configuration/VolumeRendererParameters.h>
 
 namespace livre
@@ -38,23 +37,15 @@ namespace livre
 class RenderView : public View
 {
 public:
-    LIVRE_API RenderView();
-
-    /**
-     * Sets the rendering parameters
-     * @param volumeRendererParameters Volume rendering parameters.
-     */
-    LIVRE_API void setParameters( ConstVolumeRendererParametersPtr volumeRendererParameters );
+    LIVRE_API RenderView( ConstDashTreePtr dashTree );
+    LIVRE_API ~RenderView();
 
 private:
     LIVRE_API void onPostRender_( const GLWidget& widget,
                                   const FrameInfo& frameInfo ) final;
 
-    void freeTextures_( const DashNodeVector& renderNodeList );
-
-    DashNodeSet previousVisibleSet_;
-    DFSTraversal dfsTraverser_;
-    VolumeRendererParameters volumeRendererParameters_;
+    struct Impl;
+    Impl* _impl;
 };
 
 }

--- a/livre/lib/uploaders/DataUploadProcessor.cpp
+++ b/livre/lib/uploaders/DataUploadProcessor.cpp
@@ -246,8 +246,8 @@ void DataLoaderVisitor::visit( DashRenderNode& renderNode, VisitState& state )
         return;
     }
 
-    const bool isVisible = renderNode.isVisible();
-    if( !isVisible )
+    const bool isLODVisible = renderNode.isLODVisible();
+    if( !isLODVisible )
         return;
 
     state.setVisitChild( false );
@@ -291,8 +291,8 @@ void DepthCollectorVisitor::visit( DashRenderNode& renderNode, VisitState& state
         return;
     }
 
-    const bool isVisible = renderNode.isVisible();
-    if( !isVisible )
+    const bool isLODVisible = renderNode.isLODVisible();
+    if( !isLODVisible )
         return;
 
     state.setVisitChild( false );

--- a/livre/lib/uploaders/TextureUploadProcessor.cpp
+++ b/livre/lib/uploaders/TextureUploadProcessor.cpp
@@ -95,7 +95,7 @@ public:
         if( !renderNode.isInFrustum( ))
              state.setVisitChild( false );
 
-        if( renderNode.isVisible( ))
+        if( renderNode.isLODVisible( ))
         {
             currentVisibleSet_.insert( lodNode.getNodeId().getId( ));
             state.setVisitChild( false );
@@ -229,8 +229,8 @@ void TextureLoaderVisitor::visit( DashRenderNode& renderNode, VisitState& state 
         return;
     }
 
-    const bool isVisible = renderNode.isVisible();
-    if( !isVisible )
+    const bool isLODVisible = renderNode.isLODVisible();
+    if( !isLODVisible )
         return;
 
     state.setVisitChild( false );


### PR DESCRIPTION
Previously dash tree was the enforced data source for the texture cache and
until a queried new texture object were arriving, there was no display
because object were cleaned from the tree.