### PR TITLE
Fix problem when trying to update frame range

### DIFF
--- a/livre/eq/Channel.cpp
+++ b/livre/eq/Channel.cpp
@@ -332,9 +332,8 @@ public:
         livre::Node* node = static_cast< livre::Node* >( _channel->getNode( ));
         DashTreePtr dashTree = node->getDashTree();
         const uint32_t frame = dashTree->getRenderStatus().getFrameID();
-        const VolumeInformation& volInfo =
-                dashTree->getDataSource()->getVolumeInformation();
-        const Vector2ui& frameRange = volInfo.getFrameRange();
+        const Vector2ui& frameRange =
+                getFrameData()->getFrameSettings()->getFrameRange();
         if( frame < frameRange[0] || frame >= frameRange[1] )
             return;
 

--- a/livre/eq/Node.cpp
+++ b/livre/eq/Node.cpp
@@ -28,6 +28,7 @@
 #include <livre/eq/Pipe.h>
 #include <livre/eq/Event.h>
 
+#include <livre/eq/settings/FrameSettings.h>
 #include <livre/eq/settings/VolumeSettings.h>
 #include <livre/lib/cache/TextureDataCache.h>
 #include <livre/lib/configuration/VolumeRendererParameters.h>
@@ -115,7 +116,10 @@ public:
 
         const livre::VolumeInformation& info =
                 _dataSourcePtr->getVolumeInformation();
-        _config->sendEvent( VOLUME_FRAME_RANGE ) << info.getFrameRange();
+        const Vector2ui& frameRange( info.getFrameRange( ));
+
+        _config->getFrameData().getFrameSettings()->setFrameRange( frameRange );
+        _config->sendEvent( VOLUME_FRAME_RANGE ) << frameRange;
     }
 
     void releaseVolume()

--- a/livre/eq/settings/FrameSettings.cpp
+++ b/livre/eq/settings/FrameSettings.cpp
@@ -33,6 +33,7 @@ void FrameSettings::reset()
 {
     currentViewId_ = lunchbox::uint128_t( 0 );
     frameNumber_ = 0;
+    frameRange_ = Vector2ui(0, 0);
     screenShot_ = 0;
     recording_ = false;
     statistics_ = false;
@@ -44,24 +45,33 @@ void FrameSettings::reset()
 void FrameSettings::serialize( co::DataOStream& os, const uint64_t dirtyBits )
 {
     co::Serializable::serialize( os, dirtyBits );
-    os << currentViewId_ << frameNumber_ << screenShot_
+    os << currentViewId_ << frameNumber_ << frameRange_ << screenShot_
        << recording_ << statistics_ << help_ << grabFrame_;
 }
 
 void FrameSettings::deserialize( co::DataIStream& is, const uint64_t dirtyBits )
 {
     co::Serializable::deserialize( is, dirtyBits );
-    is >> currentViewId_ >> frameNumber_ >> screenShot_
+    is >> currentViewId_ >> frameNumber_ >> frameRange_ >> screenShot_
        >> recording_ >> statistics_ >> help_ >> grabFrame_;
 }
 
 void FrameSettings::setFrameNumber( uint32_t frame )
 {
-    if( frameNumber_ == frame )
-        return;
+    if( frameNumber_ != frame )
+    {
+        frameNumber_ = frame;
+        setDirty( DIRTY_ALL );
+    }
+}
 
-    frameNumber_ = frame;
-    setDirty( DIRTY_ALL );
+void FrameSettings::setFrameRange( const Vector2ui& frameRange )
+{
+    if( frameRange_ != frameRange )
+    {
+        frameRange_ = frameRange;
+        setDirty( DIRTY_ALL );
+    }
 }
 
 void FrameSettings::makeScreenshot()

--- a/livre/eq/settings/FrameSettings.h
+++ b/livre/eq/settings/FrameSettings.h
@@ -71,6 +71,12 @@ public:
     /** @return the current frame number to render. */
     uint32_t getFrameNumber() const { return frameNumber_; }
 
+    /** Set the frame range */
+    void setFrameRange( const Vector2ui& frameRange );
+
+    /** @return the current frameRange */
+    const Vector2ui& getFrameRange() const { return frameRange_; }
+
     /**
      * Screen shots the current frame.
      */
@@ -125,6 +131,7 @@ private:
 
     eq::uint128_t currentViewId_;
     uint32_t frameNumber_;
+    Vector2ui frameRange_;
     uint32_t screenShot_;
     bool recording_;
     bool statistics_;


### PR DESCRIPTION
It fixes a problem that made the application crash when
calling getFrameRange() from different threads. Depending on
the implementation of the data source it could lead to
undefined behavior.
Now it only receives the information in the main thread, and
it is distributed in the FrameSetting (FrameData).