### PR TITLE
Quick fix for the nb samples per ray

### DIFF
--- a/livre/eq/render/RayCastRenderer.cpp
+++ b/livre/eq/render/RayCastRenderer.cpp
@@ -59,7 +59,7 @@ struct RayCastRenderer::Impl
         , _shaders( new GLSLShaders )
         , _nSamplesPerRay( samplesPerRay )
         , _nSamplesPerPixel( samplesPerPixel )
-        , _computedSamplePerRay( samplesPerRay )
+        , _computedSamplesPerRay( samplesPerRay )
         , _volInfo( volInfo )
         , _transferFunctionTexture( 0 )
     {
@@ -140,10 +140,10 @@ struct RayCastRenderer::Impl
             }
 
             const float maxVoxelDim = _volInfo.voxels.find_max();
-            const float maxVoxelsAtLOD = maxVoxelDim /
+            const float maxVoxelsAtLOD = ( maxVoxelDim * std::sqrt( 2.0f )) /
                     (float)( 1u << ( _volInfo.rootNode.getDepth() - maxLOD ));
             // Nyquist limited nb of samples according to voxel size
-            _computedSamplePerRay = 2.0f * maxVoxelsAtLOD;
+            _computedSamplesPerRay = std::max( 2.0f * maxVoxelsAtLOD, 512.f );
         }
 
         glDisable( GL_LIGHTING );
@@ -179,7 +179,7 @@ struct RayCastRenderer::Impl
         glUniform3fv( tParamNameGL, 1, frustum.getEyeCoords( ).array );
 
         tParamNameGL = glGetUniformLocation( program, "nSamplesPerRay" );
-        glUniform1i( tParamNameGL, _computedSamplePerRay );
+        glUniform1i( tParamNameGL, _computedSamplesPerRay );
 
         tParamNameGL = glGetUniformLocation( program, "nSamplesPerPixel" );
         glUniform1i( tParamNameGL, _nSamplesPerPixel );
@@ -264,7 +264,7 @@ struct RayCastRenderer::Impl
     GLSLShadersPtr _shaders;
     const uint32_t _nSamplesPerRay;
     const uint32_t _nSamplesPerPixel;
-    uint32_t _computedSamplePerRay;
+    uint32_t _computedSamplesPerRay;
     const VolumeInformation& _volInfo;
     uint32_t _transferFunctionTexture;
     std::vector< uint32_t > _usedTextures[2]; // last, current frame

--- a/livre/eq/render/shaders/fragRayCast.glsl
+++ b/livre/eq/render/shaders/fragRayCast.glsl
@@ -161,10 +161,6 @@ void main( void )
 
             if( localResult.a > EARLY_EXIT )
                 break;
-
-            if( i > nSamplesPerRay )
-                break;
-
         }
         brickResult += localResult;
     }

--- a/livre/eq/render/shaders/fragRayCast.glsl
+++ b/livre/eq/render/shaders/fragRayCast.glsl
@@ -148,11 +148,10 @@ void main( void )
         float alphaCorrection = float( DEFAULT_NSAMPLES_PER_RAY ) / float( nSamplesPerRay );
 
         vec3 pos = rayStart;
-        float travel = distance( rayStop, rayStart );
         vec3 step = normalize( rayStop - rayStart ) * stepSize;
 
         // Front-to-back absorption-emission integrator
-        for ( int i = 0; travel > 0.0; ++i, pos += step, travel -= stepSize )
+        for ( float travel = distance( rayStop, rayStart ); travel > 0.0; pos += step, travel -= stepSize )
         {
             vec3 texPos = calcTexturePositionFromAABBPos( pos );
             float density = texture3D( volumeTex, texPos ).r;


### PR DESCRIPTION
We have changed the rendering algorithm to account for eye point inside the volume. To do that, we start sampling from the eye whcih can skip the voxels on the border in the volume. This makes the low sampling problem visible ( nyquist limit is somehow overwritten ). To overcome this problem sampling should start at the borders of the volume. This will be fixed in a larger commit. Currently the min nb of samples is 512 samples when automatically computed and fixes low sampling issues. If volume is larger the number is computed against the nyquist limit.