### PR TITLE
Correct the depth of the UVF data source

### DIFF
--- a/livre/uvf/UVFDataSource.cpp
+++ b/livre/uvf/UVFDataSource.cpp
@@ -38,7 +38,6 @@
 
 #include <lunchbox/pluginRegisterer.h>
 
-#define MINIMUM_NUMBEROF_NODES 8u
 #define MAX_ACCEPTABLE_BLOCK_SIZE 512
 
 namespace livre
@@ -69,15 +68,14 @@ public:
             // For to use with MMap
             _tuvokLargeMMapFilePtr.reset( new LargeFileMMap( path ));
 
-            uint32_t depth = 0;
+            // Determine the depth of the LOD tree structure
+            uint32_t depth = -1;
             UINTVECTOR3 lodSize;
             do
             {
-                 lodSize = _uvfDataSetPtr->GetBrickLayout( depth++, 0 );
+                 lodSize = _uvfDataSetPtr->GetBrickLayout( ++depth, 0 );
             }
-            while( lodSize[0] >= MINIMUM_NUMBEROF_NODES &&
-                   lodSize[1] >= MINIMUM_NUMBEROF_NODES &&
-                   lodSize[2] >= MINIMUM_NUMBEROF_NODES  );
+            while( lodSize[0] > 1 && lodSize[1] > 1 && lodSize[2] > 1  );
 
             const UINTVECTOR3 tuvokBricksInRootLod =
                     _uvfDataSetPtr->GetBrickLayout( depth - 1, 0 );


### PR DESCRIPTION
As a result, the details in the rendering are more visible because the correct LOD is selected from data source [see screenshots]:

![wrong_tree_depth_3](https://cloud.githubusercontent.com/assets/5166658/11534989/14ed7cbc-9912-11e5-900f-daa27441a8d8.png)

![correct_tree_depth_5](https://cloud.githubusercontent.com/assets/5166658/11534995/181678c6-9912-11e5-819c-a607dd0c76df.png)
