### PR TITLE
Add parameter to limit the animation frame rate

### DIFF
--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,8 @@ Changelog {#Changelog}
 
 # master {#master}
 
+* [#333](https://github.com/BlueBrain/Livre/pull/333):
+  Add animation-fps parameter to limit the animation frame rate
 * [#318](https://github.com/BlueBrain/Livre/pull/318):
   * Added support for NRRD and Raw volumes
 * [#317](https://github.com/BlueBrain/Livre/pull/317):

--- a/livre/eq/Config.h
+++ b/livre/eq/Config.h
@@ -131,6 +131,7 @@ private:
     bool _registerFrameData();
     bool _deregisterFrameData();
     void _initEvents();
+    bool _keepCurrentFrame( uint32_t fps ) const;
 
     class Impl;
     std::unique_ptr< Impl > _impl;

--- a/livre/lib/configuration/ApplicationParameters.cpp
+++ b/livre/lib/configuration/ApplicationParameters.cpp
@@ -38,6 +38,7 @@ namespace livre
 {
 
 const std::string ANIMATION_PARAM = "animation";
+const std::string ANIMATION_FPS_PARAM = "animation-fps";
 const std::string ANIMATION_FOLLOW_DATA_PARAM = "animation-follow-data";
 const std::string FRAMES_PARAM = "frames";
 const std::string NUMFRAMES_PARAM = "num-frames";
@@ -54,10 +55,13 @@ ApplicationParameters::ApplicationParameters()
     , frames( FULL_FRAME_RANGE )
     , maxFrames( std::numeric_limits< uint32_t >::max( ))
     , animation( 0 )
+    , animationFPS( 0 )
     , isResident( false )
 {
     configuration_.addDescription( configGroupName_, ANIMATION_PARAM,
                                    "Enable animation mode (optional frame delta for animation speed, use --animation=-<int> for reverse animation)", animation, 1 );
+    configuration_.addDescription( configGroupName_, ANIMATION_FPS_PARAM,
+                                   "Animation frames per second. By default (value of 0), it will request a new frame as soon as the previous one is done", animationFPS );
     configuration_.addDescription( configGroupName_, ANIMATION_FOLLOW_DATA_PARAM,
                                    "Enable animation and follow volume data stream (overrides --animation=value)", false );
     configuration_.addDescription( configGroupName_, FRAMES_PARAM,
@@ -86,6 +90,7 @@ ApplicationParameters& ApplicationParameters::operator = (
     frames = parameters.frames;
     maxFrames = parameters.maxFrames;
     animation = parameters.animation;
+    animationFPS = parameters.animationFPS;
     isResident = parameters.isResident;
     dataFileName = parameters.dataFileName;
     transferFunction = parameters.transferFunction;
@@ -96,6 +101,7 @@ ApplicationParameters& ApplicationParameters::operator = (
 void ApplicationParameters::initialize_()
 {
     animation = configuration_.getValue( ANIMATION_PARAM, animation );
+    animationFPS = configuration_.getValue( ANIMATION_FPS_PARAM, animationFPS );
     frames = configuration_.getValue( FRAMES_PARAM, frames );
     maxFrames = configuration_.getValue( NUMFRAMES_PARAM, maxFrames );
     cameraPosition = configuration_.getValue( CAMERAPOS_PARAM, cameraPosition );

--- a/livre/lib/configuration/ApplicationParameters.h
+++ b/livre/lib/configuration/ApplicationParameters.h
@@ -40,6 +40,7 @@ struct ApplicationParameters : public Parameters
     Vector2ui frames; //!< Range of frames to render: [start end).
     uint32_t maxFrames; //!< Max number of frames to render.
     int32_t animation; //!< animation forward/backward speed
+    uint32_t animationFPS; //!< animation frames per second
     bool isResident; //!< Is the main app resident.
     std::string dataFileName; //!< Data file name.
     std::string transferFunction; //!< Path to transfer function file


### PR DESCRIPTION
Using the new --animation-fps parameter, users can now limit
the maximum number of frames per second that they will get from
the data source. Note that this won't affect the rendering rate,
but just the animation rate. By default it gets a value of 0,
setting a new frame as soon as the previous one is finished