### PR TITLE
Adapt to latest ZeroEQ handle(endpoint, ...) changes

### DIFF
--- a/livre/eq/Config.cpp
+++ b/livre/eq/Config.cpp
@@ -33,8 +33,6 @@
 #include <livre/core/data/VolumeInformation.h>
 #include <livre/core/util/FrameUtils.h>
 
-#include <lexis/render/imageJPEG.h>
-
 #ifdef LIVRE_USE_ZEROEQ
 #include <livre/eq/zeroeq/communicator.h>
 #endif
@@ -103,7 +101,7 @@ const FrameData& Config::getFrameData() const
     return _impl->framedata;
 }
 
-std::string Config::renderJPEG()
+void Config::renderJPEG(::lexis::render::ImageJPEG& target)
 {
     getFrameData().getFrameSettings().setGrabFrame(true);
     frame();
@@ -120,14 +118,12 @@ std::string Config::renderJPEG()
             const uint8_t* data = reinterpret_cast<const uint8_t*>(
                 event.getRemainingBuffer(size));
 
-            ::lexis::render::ImageJPEG imageJPEG;
-            imageJPEG.setData(data, size);
-            return imageJPEG.toJSON();
+            target.setData(data, size);
+            return;
         }
 
         handleEvent(event);
     }
-    return "";
 }
 
 void Config::setHistogram(const Histogram& histogram)

--- a/livre/eq/Config.h
+++ b/livre/eq/Config.h
@@ -28,6 +28,8 @@
 #include <livre/eq/api.h>
 #include <livre/eq/types.h>
 
+#include <lexis/render/imageJPEG.h>
+
 namespace livre
 {
 /** Drives a configuration, aka the main application loop. */
@@ -104,7 +106,7 @@ public:
 
     void handleNetworkEvents();
 
-    std::string renderJPEG();
+    void renderJPEG(::lexis::render::ImageJPEG& target);
 
     /** @return the current volume information. */
     const VolumeInformation& getVolumeInformation() const;


### PR DESCRIPTION
ZeroEQ no longer modifies the endpoint passed to handle(endpoint, ...), so using the ZEROBUF_TYPE_NAME() would not register the expected endpoints. Using Serializable objects to preserve existing behaviour.

I'm opening this PR for information at this point, assuming we agree on the changes in https://github.com/HBPVIS/ZeroEQ/pull/203

One reasonable alternative that I see is to make the endpoint conversion function public in zeroeq/http/helpers.h and use it in livre/eq/zeroeq/communicator.cpp.

No other projects should need to be modified.
